### PR TITLE
fix compiler warnings in Elixir 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ end
 
 ## Changelog
 
+ - `v1.1.1` Fix warning for Elixir 1.10
  - `v1.1.0` Adds types to the enum. Dialyzer might start complaining.
 
 ## Creating and using an Enum

--- a/lib/enum_type.ex
+++ b/lib/enum_type.ex
@@ -52,7 +52,7 @@ defmodule EnumType do
 
           Module.register_attribute(__MODULE__, :possible_options, accumulate: true)
 
-          if Code.ensure_compiled?(Ecto.Type) do
+          if {:module, _module} = Code.ensure_compiled(Ecto.Type) do
             @behaviour Ecto.Type
 
             def type, do: unquote(ecto_type)
@@ -64,7 +64,7 @@ defmodule EnumType do
 
           unquote(block)
 
-          if Code.ensure_compiled?(Ecto.Type) do
+          if {:module, _module} = Code.ensure_compiled(Ecto.Type) do
             # Default fallback ecto conversion options.
             def cast(_), do: :error
             def load(_), do: :error
@@ -109,7 +109,7 @@ defmodule EnumType do
 
       def value(unquote(option)), do: unquote(option).value
 
-      if Code.ensure_compiled?(Ecto.Type) do
+      if {:module, _module} = Code.ensure_compiled(Ecto.Type) do
         # Support querying by both the Enum module and the specific value.
         # Error will occur if an invalid value is attempted to be used.
         def cast(unquote(option)), do: {:ok, unquote(option)}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule EnumType.MixProject do
   use Mix.Project
 
-  @version "1.1.0"
+  @version "1.1.1"
 
   def project do
     [


### PR DESCRIPTION
A somewhat ugly fixes to the compiler warnings. However the risk of a compiler deadlock is extremely remote since this is only depending on Ecto being loaded. Ecto won't be depending on this library.