### PR TITLE
Allow single valued enums

### DIFF
--- a/lib/enum_type.ex
+++ b/lib/enum_type.ex
@@ -37,7 +37,10 @@ defmodule EnumType do
   end
 
   defmacro defenum(name, ecto_type, do: block) do
-    {:__block__, _, block_body} = block
+    block_body = case block do
+      {:__block__, _, block_body} -> block_body
+      {:value, _, _} = block_body -> [block_body]
+    end
 
     values =
       Enum.reduce(block_body, [], fn


### PR DESCRIPTION
This will allow single valued enums like

```
defenum SingleValuedEnum do
  value OneValue, "one"
end
```