### PR TITLE
Fix formatter

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,8 +1,10 @@
 # Used by "mix format"
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  import: [:ecto],
   locals_without_parens: [
     defenum: :*,
-    value: :*
+    value: :*,
+    default: 1,
   ]
 ]


### PR DESCRIPTION
When `~$ mix format` in this project, the parens of some macros added because of missing config in `.formatter.exs`